### PR TITLE
[VE-7612] Fix codec errors

### DIFF
--- a/yolo_sod/__init__.py
+++ b/yolo_sod/__init__.py
@@ -6,6 +6,7 @@ CODEC_MAP = {
     "mpeg1video": "mpeg1_cuvid",
     "mpeg2video": "mpeg2_cuvid",
     "mpeg4video": "mpeg4_cuvid",
+    "mpeg4": "mpeg4_cuvid",
     "vc1": "vc1_cuvid",
     "vp8": "vp8_cuvid",
     "vp9": "vp9_cuvid",

--- a/yolo_sod/inference.py
+++ b/yolo_sod/inference.py
@@ -44,20 +44,20 @@ def filler(
         padding (Tuple[int, int, int, int]): Padding to apply to the video
 
     """
-    s = StreamReader(input_path)
-    s.add_video_stream(
-        batch_size,
-        decoder=CODEC_MAP[codec],
-        hw_accel="cuda:0",
-        buffer_chunk_size=-1,
-        decoder_option={"resize": f"{decode_width}x{decode_height}"},
-    )
-    padding_function = torch.nn.ZeroPad2d(padding)
-
-    current_batch_size = batch_size
-
-    finished = False
     try:
+        s = StreamReader(input_path)
+        s.add_video_stream(
+            batch_size,
+            decoder=CODEC_MAP[codec],
+            hw_accel="cuda:0",
+            buffer_chunk_size=-1,
+            decoder_option={"resize": f"{decode_width}x{decode_height}"},
+        )
+        padding_function = torch.nn.ZeroPad2d(padding)
+
+        current_batch_size = batch_size
+
+        finished = False
         while not finished:  # 1 means EOF
             finished = s.fill_buffer() == 1  # 1 means EOF
             (video,) = s.pop_chunks()
@@ -84,7 +84,7 @@ def filler(
         inference_finished.wait()
     except Exception as e:
         # Catch any exceptions and notify the inference loop (otherwise it will hang indefinitely)
-        print(e)
+        print(f"{type(e).__name__}: {e}")
         filler_finished.set()
         queue.put((None, 0))
 


### PR DESCRIPTION
# Description

Fixes hanging when the codec cannot be found in the codec map.

# Details

- Wraps the entire decoder thread in a `try` block to catch all possible errors.
- Adds extra codec `mpeg4` to codec map.
- Improves error print outs when decoder thread fails.

# Testing

The various test files listed in the ticket should now behave as expected.